### PR TITLE
Fixed the reference from the RegisterCaretaker to the AddRepository

### DIFF
--- a/src/PBot/Caretakers/RegisterCaretaker.cs
+++ b/src/PBot/Caretakers/RegisterCaretaker.cs
@@ -9,7 +9,7 @@ namespace PBot.Caretakers
         public RegisterCaretaker()
             : base(
                 "register (.*) (as caretaker for) (.*)$",
-                "mmbot register <user> as caretaker for <repository> - registers the given user as the caretaker for the repo. The repo must exist. If not register is using mmbot register repository <name of repo>") { }
+                "pbot register <user> as caretaker for <repository> - registers the given user as the caretaker for the repo. The repo must exist. If not register is using pbot add repo <name of repo>") { }
 
         public override async Task Execute(string[] parameters, IResponse response)
         {


### PR DESCRIPTION
Adding a caretaker had the wrong reference to AddRepository command in the help text

@janovesk please review and merge