### PR TITLE
WIP: move issue and keep labels

### DIFF
--- a/src/PBot.Tests.Integration/PBot.Tests.Integration.csproj
+++ b/src/PBot.Tests.Integration/PBot.Tests.Integration.csproj
@@ -150,6 +150,7 @@
     <Compile Include="RemindWhenMoreRequirementsNeedsToBeApprovedTests.cs" />
     <Compile Include="ShowAllCurrentlyFailedBuildsTests.cs" />
     <Compile Include="TeamCityTests.cs" />
+    <Compile Include="When_transfering_an_issue_between_repos.cs" />
     <Compile Include="When_adding_a_new_repo_to_pbot.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PBot.Tests.Integration/When_transfering_an_issue_between_repos.cs
+++ b/src/PBot.Tests.Integration/When_transfering_an_issue_between_repos.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Octokit;
+using PBot.Issues;
+
+public class When_transfering_an_issue_between_repos : GitHubIntegrationTest
+{
+    [Test]
+    [Explicit]
+    public async Task Should_assign_label_to_match_original_issue()
+    {
+        var srcRepoInfo = new RepoInfo { Name = RepositoryName, Owner = RepositoryOwner };
+        var dstRepoInfo = new RepoInfo { Name = RepositoryName + "-copy", Owner = RepositoryOwner };
+        var dstRepo = await GitHubClient.Repository.Create(new NewRepository { Name = dstRepoInfo.Name });
+
+        var labelTemplate = new NewLabel("Test-Label", "123456");
+        var label = await GitHubClient.Issue.Labels.Create(srcRepoInfo.Owner, srcRepoInfo.Name, labelTemplate);
+        await GitHubClient.Issue.Labels.Create(dstRepoInfo.Owner, dstRepoInfo.Name, labelTemplate);
+        var issue = new NewIssue("test issue with label") { Body = "Issue should have a label" };
+        issue.Labels.Add(label.Name);
+        var originalIssue = await GitHubClient.Issue.Create(srcRepoInfo.Owner, srcRepoInfo.Name, issue);
+
+        var copiedIssue = IssueUtility.Transfer(srcRepoInfo, originalIssue.Number, dstRepoInfo, true).Result;
+
+        Helper.DeleteRepo(dstRepo);
+
+        Assert.AreEqual(originalIssue.Labels.Count, copiedIssue.Labels.Count);
+        Assert.AreEqual(originalIssue.Labels.First().Name, copiedIssue.Labels.First().Name);
+        Assert.AreEqual(originalIssue.Labels.First().Color, copiedIssue.Labels.First().Color);
+    }
+}

--- a/src/PBot.Tests/LabelUtilityTest.cs
+++ b/src/PBot.Tests/LabelUtilityTest.cs
@@ -1,0 +1,57 @@
+﻿namespace PBot.Tests
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Octokit;
+    using PBot.Issues;
+
+    [TestFixture]
+    public class LabelUtilityTest
+    {
+        [Test]
+        public async Task Should_find_label_that_exists()
+        {
+            const string labelName = "Bug";
+            const string labelColor = "eb6420";
+            var repoInfo = new RepoInfo { Name = "RepoStandards", Owner = "Particular" };
+
+            var result = await LabelUtility.RepositoryHasLabels(repoInfo, new Label(null, labelName, labelColor));
+            Assert.True(result, "Should return true");
+        }
+        
+        [Test]
+        public async Task Should_not_find_label_that_does_not_exist()
+        {
+            const string labelName = "NonExistentLabel";
+            const string labelColor = "000000";
+            var repoInfo = new RepoInfo { Name = "RepoStandards", Owner = "Particular" };
+
+            var result = await LabelUtility.RepositoryHasLabels(repoInfo, new Label(null, labelName, labelColor));
+            Assert.False(result, "Should return false");
+        }
+
+        [Test]
+        public async Task Should_find_multiple_labels()
+        {
+            var label1 = new Label(null, "Bug", "eb6420");
+            var label2 = new Label(null, "Feature", "02e10c");
+            
+            var repoInfo = new RepoInfo { Name = "RepoStandards", Owner = "Particular" };
+
+            var result = await LabelUtility.RepositoryHasLabels(repoInfo, label1, label2);
+            Assert.True(result, "Should return true");
+        }
+
+        [Test]
+        public async Task Should_not_find_labels_if_one_of_them_does_not_exist()
+        {
+            var label1 = new Label(null, "Bug", "eb6420");
+            var label2 = new Label(null, "NonExistentLabel", "000000");
+            
+            var repoInfo = new RepoInfo { Name = "RepoStandards", Owner = "Particular" };
+
+            var result = await LabelUtility.RepositoryHasLabels(repoInfo, label1, label2);
+            Assert.False(result, "Should return false");
+        }
+    }
+}

--- a/src/PBot.Tests/PBot.Tests.csproj
+++ b/src/PBot.Tests/PBot.Tests.csproj
@@ -135,6 +135,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LabelUtilityTest.cs" />
     <Compile Include="NotifyCaretakersOfCurrentlyFailedBuildsTests.cs" />
     <Compile Include="RepoParserTests.cs" />
     <Compile Include="BotCommandTests.cs" />

--- a/src/PBot/Issues/IssueUtility.cs
+++ b/src/PBot/Issues/IssueUtility.cs
@@ -1,6 +1,7 @@
 ﻿namespace PBot.Issues
 {
     using System.IO;
+    using System.Linq;
     using System.Threading.Tasks;
     using Octokit;
 
@@ -12,6 +13,7 @@
 
             var sourceIssue = await client.Issue.Get(sourceRepository.Owner, sourceRepository.Name, sourceIssueNumber);
             var sourceComments = await client.Issue.Comment.GetForIssue(sourceRepository.Owner, sourceRepository.Name, sourceIssueNumber);
+            var sourceLabels = await client.Issue.Labels.GetForIssue(sourceRepository.Owner, sourceRepository.Name, sourceIssueNumber);
 
             var newBody = string.Format(
                 @"<a href=""{0}""><img src=""{1}"" align=""left"" width=""96"" height=""96"" hspace=""10""></img></a> **Issue by [{2}]({0})**
@@ -64,6 +66,12 @@ _{3}_
                 };
                 await client.Issue.Update(targetRepository.Owner, targetRepository.Name, targetIssue.Number, issueUpdate);
             }
+
+            if (sourceLabels.Any())
+            {
+                await client.Issue.Labels.AddToIssue(targetRepository.Owner, targetRepository.Name, targetIssue.Number, sourceLabels.Select(x => x.Name).ToArray());
+            }
+
             return await client.Issue.Get(targetRepository.Owner, targetRepository.Name, targetIssue.Number);
         }
     }

--- a/src/PBot/Issues/LabelUtility.cs
+++ b/src/PBot/Issues/LabelUtility.cs
@@ -1,0 +1,28 @@
+﻿namespace PBot.Issues
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Octokit;
+
+    class LabelUtility
+    {
+        public static async Task<bool> RepositoryHasLabels(RepoInfo repo, params Label[] labels)
+        {
+            var client = GitHubClientBuilder.Build();
+            var existingLabels = await client.Issue.Labels.GetForRepository(repo.Owner, repo.Name);
+ 
+            foreach (var label in labels)
+            {
+                var foundLabel = existingLabels.SingleOrDefault(l => l.Name.Equals(label.Name, StringComparison.InvariantCulture));
+
+                if (foundLabel == null || foundLabel.Color != label.Color)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/PBot/Issues/MoveIssue.cs
+++ b/src/PBot/Issues/MoveIssue.cs
@@ -1,5 +1,6 @@
 ﻿namespace PBot.Issues
 {
+    using System.Linq;
     using System.Threading.Tasks;
 
     public class MoveIssue : BotCommand
@@ -38,6 +39,14 @@
             var dst = new RepoInfo { Owner = "Particular", Name = targetRepo };
 
             await response.Send(string.Format("Moving issue https://github.com/Particular/{0}/issues/{1}", sourceRepo, issueNumber)).IgnoreWaitContext();
+
+            var client = GitHubClientBuilder.Build();
+            var labels = await client.Issue.Labels.GetForIssue(src.Owner, src.Name, issueNumber);
+            var labelsExist = await LabelUtility.RepositoryHasLabels(dst, labels.ToArray());
+            if (!labelsExist)
+            {
+                await response.Send(string.Format("Could not move issue https://github.com/Particular/{0}/issues/{1}. Destination repo {2} doesn't have issue labels. Please create labels in target repo first.", sourceRepo, issueNumber, targetRepo)).IgnoreWaitContext();
+            }
 
             var newIssue = await IssueUtility.Transfer(src, issueNumber, dst, true).IgnoreWaitContext();
 

--- a/src/PBot/Issues/MoveIssue.cs
+++ b/src/PBot/Issues/MoveIssue.cs
@@ -45,7 +45,7 @@
             var labelsExist = await LabelUtility.RepositoryHasLabels(dst, labels.ToArray());
             if (!labelsExist)
             {
-                await response.Send(string.Format("Could not move issue https://github.com/Particular/{0}/issues/{1}. Destination repo {2} doesn't have issue labels. Please create labels in target repo first.", sourceRepo, issueNumber, targetRepo)).IgnoreWaitContext();
+                await response.Send(string.Format("Could not move issue https://github.com/Particular/{0}/issues/{1} due to missing labels in destination repo {2}. Please execute Pbot.Tests.UpdateRepoLabelsTests test to create label in destination repo.", sourceRepo, issueNumber, targetRepo)).IgnoreWaitContext();
             }
 
             var newIssue = await IssueUtility.Transfer(src, issueNumber, dst, true).IgnoreWaitContext();

--- a/src/PBot/PBot.csproj
+++ b/src/PBot/PBot.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Issues\IssueState.cs" />
     <Compile Include="Issues\IssueStateExtensions.cs" />
     <Compile Include="Issues\IssueUtility.cs" />
+    <Compile Include="Issues\LabelUtility.cs" />
     <Compile Include="Issues\MoveIssue.cs" />
     <Compile Include="OctoExtensions.cs" />
     <Compile Include="Octopus\CreateTeamCityProject.cs" />

--- a/src/PBot/Properties/AssemblyInfo.cs
+++ b/src/PBot/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -20,4 +21,6 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("53147fff-9e53-4e25-878d-5a5fd19521ba")]
+[assembly: InternalsVisibleTo("PBot.Tests.Integration")]
+[assembly: InternalsVisibleTo("PBot.Tests")]
 


### PR DESCRIPTION
**Warning**: this is not completed yet and requires more explicit testing.

I have tried to address the fact that we're moving issues from one repo to another w/o checking if labels exist or not. _When_transfering_an_issue_between_repos_ is mimicking a scenario where an issue is copied from _src_ repo to _dst_ repo and both repos have issue label.

connects to #32