### PR TITLE
pbot pig showing duplicate issues when assigned and in TF

### DIFF
--- a/src/PBot/Issues/InvolvedIssueQuery.cs
+++ b/src/PBot/Issues/InvolvedIssueQuery.cs
@@ -53,6 +53,8 @@ namespace PBot.Issues
                 .Concat(
                     creatorQuery.Result
                         .Where(issue => issue.PullRequest != null))
+                .GroupBy(issue => issue.Url)
+                .Select(g => g.First())
                 .Select(issue => new InvolvedIssue { Issue = issue, Repo = repo });
         }
 


### PR DESCRIPTION
If you're assigned to an issue ​*and*​ listed in the task force, the issue appears twice in the output.